### PR TITLE
Add actiongroup toggle, user configurable EC_amount and fixed Target ray and Target Mark issues

### DIFF
--- a/Parts/MM_KSPCamera.cfg
+++ b/Parts/MM_KSPCamera.cfg
@@ -4,5 +4,6 @@
 	{
 		name = DockingCameraModule
 		noise = true
+		electricchargeCost = 0.02
 	}
 }

--- a/Parts/OnboardCamera.cfg
+++ b/Parts/OnboardCamera.cfg
@@ -34,6 +34,7 @@ PART
 		windowSize = 300  // initial camera window size
 		allowedScanDistance = 1000 //max allowed distance for scanning experiment
 		resourceScanning = ElectricCharge.50  //(resourseName/resourceUsage) for scanning
+		electricchargeCost = 0.02
 	}
 
 	MODULE

--- a/Source/Camera/BaseCamera.cs
+++ b/Source/Camera/BaseCamera.cs
@@ -480,8 +480,6 @@ namespace OLDD_camera.Camera
 
                 AllCamerasGameObject[0].transform.rotation = AllCamerasGameObject.Last().transform.rotation;
                 AllCamerasGameObject[1].transform.rotation = AllCamerasGameObject.Last().transform.rotation;
-                AllCamerasGameObject[2].transform.rotation = AllCamerasGameObject.Last().transform.rotation;
-                AllCamerasGameObject[2].transform.position = AllCamerasGameObject.Last().transform.position;
                 AllCameras.ForEach(cam => cam.fieldOfView = CurrentZoom);
             }
         }

--- a/Source/Camera/BaseCamera.cs
+++ b/Source/Camera/BaseCamera.cs
@@ -13,6 +13,7 @@ namespace OLDD_camera.Camera
     {
         protected static int WindowCount;
         protected static double ElectricChargeAmount;
+        internal double electricchargeCost = 0.02d;
         public static Material CurrentShader;
         protected UpdateGUIObject UpdateGUIObject;
 
@@ -233,6 +234,10 @@ namespace OLDD_camera.Camera
                 UpdateGUIObject.updateGUIFunction -= Begin; //lll
         }
 
+        public void setECusageCost(double ECAmount) 
+        {
+            electricchargeCost = ECAmount;
+        }
 
         private void Begin() //draw main window
         {
@@ -244,7 +249,7 @@ namespace OLDD_camera.Camera
             double electricChargeMaxAmount;
             ThisPart.GetConnectedResourceTotals(electricityId, out electricChargeAmount, out electricChargeMaxAmount);
             if (HighLogic.LoadedSceneIsFlight && !FlightDriver.Pause)
-                ThisPart.RequestResource(electricityId, 0.02 * TimeWarp.fixedDeltaTime);
+                ThisPart.RequestResource(electricityId, electricchargeCost * TimeWarp.fixedDeltaTime);
         }
 
         #region DRAW LAYERS 

--- a/Source/Camera/DockingCamera.cs
+++ b/Source/Camera/DockingCamera.cs
@@ -430,8 +430,6 @@ namespace OLDD_camera.Camera
 
             AllCamerasGameObject[0].transform.rotation = AllCamerasGameObject.Last().transform.rotation; // skybox galaxy
             AllCamerasGameObject[1].transform.rotation = AllCamerasGameObject.Last().transform.rotation; // nature object
-            AllCamerasGameObject[2].transform.rotation = AllCamerasGameObject.Last().transform.rotation; // middle 
-            AllCamerasGameObject[2].transform.position = AllCamerasGameObject.Last().transform.position;
             AllCameras.ForEach(cam => cam.fieldOfView = CurrentZoom);
         }
     }

--- a/Source/Camera/DockingCamera.cs
+++ b/Source/Camera/DockingCamera.cs
@@ -90,7 +90,7 @@ namespace OLDD_camera.Camera
         }
 
         public DockingCamera(OLDD_camera.Modules.DockingCameraModule dcm, Part thisPart,
-            bool noise, bool crossStock, bool crossDPAI, bool crossOLDD, bool transformModification,
+            bool noise, double electricchargeCost, bool crossStock, bool crossDPAI, bool crossOLDD, bool transformModification,
             int windowSize, string restrictShaderTo,
             string windowLabel = "DockCam", string cameraName = "dockingNode", 
             bool slidingOptionWindow = false, bool allowZoom = false, bool noTransformMod = false)

--- a/Source/Camera/PartCamera.cs
+++ b/Source/Camera/PartCamera.cs
@@ -80,7 +80,7 @@ namespace OLDD_camera.Camera
             set { CurrentZoom = value; }
         }
 
-        public PartCamera(Part thisPart, string resourceScanning, string bulletName, int hits,
+        public PartCamera(Part thisPart, string resourceScanning, double electricchargeCost, string bulletName, int hits,
                 string rotatorZ, string rotatorY, string zoommer, float stepper, string cameraName, int allowedScanDistance,
                 int windowSize, bool isOnboard, bool isLookAtMe, bool isLookAtMeAutoZoom, bool isFollowMe, bool isTargetCam,
                 float isFollowMeOffsetX, float isFollowMeOffsetY, float isFollowMeOffsetZ, float targetOffset, string restrictShaderTo,

--- a/Source/Camera/PartCamera.cs
+++ b/Source/Camera/PartCamera.cs
@@ -154,10 +154,11 @@ namespace OLDD_camera.Camera
 
         public override void Activate()
         {
-            base.Activate();
+            InitTextures();
             SetFreeId();
             WindowPosition.x = WindowPosition.width * (_id - 1);
             WindowPosition.y = 64;
+            base.Activate();
         }
 
         public override void Deactivate()
@@ -520,8 +521,6 @@ namespace OLDD_camera.Camera
 
             AllCamerasGameObject[0].transform.rotation = AllCamerasGameObject.Last().transform.rotation;
             AllCamerasGameObject[1].transform.rotation = AllCamerasGameObject.Last().transform.rotation;
-            AllCamerasGameObject[2].transform.rotation = AllCamerasGameObject.Last().transform.rotation;
-            AllCamerasGameObject[2].transform.position = AllCamerasGameObject.Last().transform.position;
             AllCameras.ForEach(cam => cam.fieldOfView = RealZoom); //currentZoom); 
             //AllCameras.ForEach(delegate (UnityEngine.Camera cam) //lll
             //{
@@ -538,7 +537,7 @@ namespace OLDD_camera.Camera
             Vector3 endPoint;
             if (!IsInsight(out endPoint)) return;
             _scanningRay = new GameObject("scanningRay").AddComponent<LineRenderer>();
-            _scanningRay.material = new Material(Shader.Find("Particles/Additive"));
+            _scanningRay.material = new Material(Shader.Find("Legacy Shaders/Particles/Additive"));
             // The following commented lines were obsolete, replaced with the methods immediately following.
             // The old lines were left as historical documentation
 
@@ -566,7 +565,7 @@ namespace OLDD_camera.Camera
             if (!TargetHelper.IsTargetSelect || !IsTargetVisiable()) return;
             _visibilityRay = new GameObject("visibilityRay").AddComponent<LineRenderer>();
             var color = Color.white;
-            _visibilityRay.material = new Material(Shader.Find("Particles/Additive"));
+            _visibilityRay.material = new Material(Shader.Find("Legacy Shaders/Particles/Additive"));
 
             // The following commented lines were obsolete, replaced with the methods immediately following.
             // The old lines were left as historical documentation

--- a/Source/CameraAdjust/InFlightMarkerCam.cs
+++ b/Source/CameraAdjust/InFlightMarkerCam.cs
@@ -84,7 +84,7 @@ namespace OLDD_camera.CameraAdjust
             _markerCamObject.AddComponent<MarkerCamBehaviour>(); // TODO can this be removed?
 
             // Set the culling mask. 
-            MarkerCam.cullingMask = 1 << 17;
+            MarkerCam.cullingMask = 1 << 16;
         }
 
         internal static UnityEngine.Camera GetMarkerCam()

--- a/Source/Modules/DockingCameraModule.cs
+++ b/Source/Modules/DockingCameraModule.cs
@@ -70,6 +70,15 @@ namespace OLDD_camera.Modules
         [KSPField]
         public bool devMode = false;
 
+        [KSPAction("Toggle Docking Camera")]
+        public void EnableAction(KSPActionParam param)
+        {
+            if (IsEnabled)
+                IsEnabled = false;
+            else
+                IsEnabled = true;
+        }
+
         CameraAdjust.CameraAdjuster ca = null;
         [KSPEvent(guiActive = true, guiName = "Camera Adjuster")]
         public void StartCameraAdjuster()

--- a/Source/Modules/DockingCameraModule.cs
+++ b/Source/Modules/DockingCameraModule.cs
@@ -20,6 +20,9 @@ namespace OLDD_camera.Modules
         public bool noise;
 
         [KSPField(isPersistant = true)]
+        public double electricchargeCost = 0.02d;
+        
+        [KSPField(isPersistant = true)]
         private bool _crossDPAI;
 
         [KSPField(isPersistant = true)]
@@ -108,12 +111,12 @@ namespace OLDD_camera.Modules
             {
                 if(cameraName != "")
                     _camera = new DockingCamera(this, part, 
-                        noise, targetCrossStockOnAtStartup, crossDPAIonAtStartup, crossOLDDonAtStartup, transformModification,
+                        noise, electricchargeCost, targetCrossStockOnAtStartup, crossDPAIonAtStartup, crossOLDDonAtStartup, transformModification,
                         _windowSize, restrictShaderTo,
                         windowLabel, cameraName, slidingOptionWindow, allowZoom);
                 else
                     _camera = new DockingCamera(this, part, 
-                        noise, targetCrossStockOnAtStartup, crossDPAIonAtStartup, crossOLDDonAtStartup, transformModification,
+                        noise, electricchargeCost, targetCrossStockOnAtStartup, crossDPAIonAtStartup, crossOLDDonAtStartup, transformModification,
                         _windowSize, restrictShaderTo);
             }
             if (cameraLabel != "")
@@ -125,6 +128,7 @@ namespace OLDD_camera.Modules
             {
                 Events["StartCameraAdjuster"].guiActive = false;
             }
+            _camera.setECusageCost(electricchargeCost);
         }
 
         public override void OnUpdate()

--- a/Source/Modules/PartCameraModule.cs
+++ b/Source/Modules/PartCameraModule.cs
@@ -38,6 +38,9 @@ namespace OLDD_camera.Modules
 
         [KSPField]
         public string resourceScanning = "ElectricCharge.50";
+        
+        [KSPField(isPersistant = true)]
+        public double electricchargeCost = 0.02d;
 
         private readonly string _cameraName = "CamExt";
         private readonly string _rotatorZ = "Case";
@@ -85,7 +88,7 @@ namespace OLDD_camera.Modules
         {
             if (_camera != null) return;
 
-                _camera = new PartCamera(part, resourceScanning, _bulletName, _currentHits, _rotatorZ, _rotatorY, _zoommer, 
+                _camera = new PartCamera(part, resourceScanning, electricchargeCost, _bulletName, _currentHits, _rotatorZ, _rotatorY, _zoommer, 
                     _stepper, _cameraName, allowedScanDistance, windowSize, _isOnboard, _isLookAtMe, _isLookAtMeAutoZoom,
                     _isFollowMe, _isTargetCam, _isFollowMeOffsetX, _isFollowMeOffsetY, _isFollowMeOffsetZ, _targetOffset, restrictShaderTo);
 
@@ -96,7 +99,7 @@ namespace OLDD_camera.Modules
             _camera.InitialCamPosition = _camera.CurrentCamPosition = _camObject.transform.position;
             _camera.InitialCamLocalRotation = _camera.CurrentCamLocalRotation = _camObject.transform.localRotation;
             _camera.InitialCamLocalPosition = _camera.CurrentCamLocalPosition = _camObject.transform.localPosition;
-
+            _camera.setECusageCost(electricchargeCost);
             
         }
 

--- a/Source/Modules/PartCameraModule.cs
+++ b/Source/Modules/PartCameraModule.cs
@@ -81,7 +81,10 @@ namespace OLDD_camera.Modules
             if (IsEnabled)
                 IsEnabled = false;
             else
+            {
+                GetElectricState();
                 IsEnabled = true;
+            }
         }
 
         public override void OnStart(StartState state)
@@ -133,8 +136,6 @@ namespace OLDD_camera.Modules
             {
                 if (IsEnabled)
                     ScreenMessages.PostScreenMessage("ELECTRICITY HAS BEEN DEPLETED", 3f, ScreenMessageStyle.UPPER_CENTER);
-                else
-                    GetElectricState();
                 _camera.IsButtonOff = true;
             }
 

--- a/Source/Modules/PartCameraModule.cs
+++ b/Source/Modules/PartCameraModule.cs
@@ -133,6 +133,8 @@ namespace OLDD_camera.Modules
             {
                 if (IsEnabled)
                     ScreenMessages.PostScreenMessage("ELECTRICITY HAS BEEN DEPLETED", 3f, ScreenMessageStyle.UPPER_CENTER);
+                else
+                    GetElectricState();
                 _camera.IsButtonOff = true;
             }
 

--- a/Source/Modules/PartCameraModule.cs
+++ b/Source/Modules/PartCameraModule.cs
@@ -72,6 +72,14 @@ namespace OLDD_camera.Modules
         [KSPField(isPersistant = true)]
         private float _targetOffset = 100;
 
+        [KSPAction("Toggle Camera")]
+        public void ToggleCameraAction(KSPActionParam param)
+        {
+            if (IsEnabled)
+                IsEnabled = false;
+            else
+                IsEnabled = true;
+        }
 
         public override void OnStart(StartState state)
         {


### PR DESCRIPTION
Reordered PartCamera.cs Activate() function. It was also missing the InitTextures() which was causing the Target marker to not load. 

Added ActionGroup for camera activation to both part modules

Corrected the shader reference path to: 'Legacy Shaders/Particles/Additive '. Was causing NRE errors if bullets or Target ray buttons were used.

Added user config option to set EC amount for camera usage. Was hard coded to 0.02. Updated part cfg files to match.

Found a logic hole in the PartCameraModule. When  a camera isEnabled (after being activated())  it does regular checks for electric charge. Once EC gets to zero, the mod will deactivate the camera (docking cameras are unaffected) and set isEnabled & _isPowered to "FALSE". 
In this state, there is no way to get back to IsEnabled = true due to there being a power state check before allowing a user to enable a camera. No EC checks are ever run again and the camera cannot be used.

Added code to do an ECcheck before trying to enable the camera to avoid this issue. 